### PR TITLE
Updating VPC configuration to assign public IP's

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -145,9 +145,10 @@ module "vpc" {
   public_subnets  = var.aws_vpc_public_subnets
   private_subnets = var.aws_vpc_private_subnets
 
-  enable_nat_gateway   = true
-  single_nat_gateway   = true
-  enable_dns_hostnames = true
+  enable_nat_gateway      = true
+  single_nat_gateway      = true
+  enable_dns_hostnames    = true
+  map_public_ip_on_launch = true
 
   tags = local.resource_tags
 


### PR DESCRIPTION
The EKS clusters fail to deploy because the public subnets we create don't assign a public IP address. Added _map_public_ip_on_launch = true to the configuration to resolve this issue. 